### PR TITLE
Ignore user_op.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tensorflow/python/tensorflow_wrap.cxx
 tensorflow/python/tf_python.py
 tensorflow/cc/ops/no_op.cc
 tensorflow/cc/ops/no_op.h
+tensorflow/cc/ops/user_op.h


### PR DESCRIPTION
This file is generated and leaves the src tree dirty after a build.